### PR TITLE
forces serializeDecimal128 to Buffer value.bytes

### DIFF
--- a/lib/bson/parser/serializer.js
+++ b/lib/bson/parser/serializer.js
@@ -321,7 +321,7 @@ var serializeDecimal128 = function(buffer, key, value, index, isArray) {
   index = index + numberOfWrittenBytes;
   buffer[index++] = 0;
   // Write the data from the value
-  value.bytes.copy(buffer, index, 0, 16);
+  Buffer.from(value.bytes).copy(buffer, index, 0, 16);
   return index + 16;
 }
 


### PR DESCRIPTION
The function serializeDecimal128 is assuming that "value.bytes" is always a Buffer type.
That is not true since right now it is a String.